### PR TITLE
Feat (Options): Add the `beforeFire` option

### DIFF
--- a/src/autoinput.esm.js
+++ b/src/autoinput.esm.js
@@ -5,6 +5,7 @@ class AutoInput {
     #selectAuto;
     #canPast;
     #createAuto;
+    #beforeFire;
     #parent;
     #validate;
     #onCreate;
@@ -19,6 +20,7 @@ class AutoInput {
      * @param {boolean} options.selectAuto If the input should auto select the first input field.
      * @param {boolean} options.canPast If the input should allow pasting.
      * @param {boolean} options.createAuto If the AutoInput should create the HTML inputs automatically.
+     * @param {number} options.beforeFire Will waits `beforeFire` milliseconds before firing the event.
      * @param {Function} options.onCreate The callback when the AutoInput creates the HTML inputs.
      * @param {HTMLElement} options.parent The parent were the child will automatically generate the HTML inputs.
      * @param {HTMLElement} options.validate The validate button to validate the entry.
@@ -28,6 +30,7 @@ class AutoInput {
         this.#selectAuto = options.selectAuto || true;
         this.#canPast = options.canPast || true;
         this.#createAuto = options.createAuto || false;
+        this.#beforeFire = options.beforeFire ?? 400;
         this.#parent = options.parent
                         || document.getElementById("a2fParent")
                         || document.querySelector("[data-parent-a2f]");
@@ -102,7 +105,7 @@ class AutoInput {
 
         setTimeout(() => {
             if (this.#validatingTime &&
-                this.#validatingTime + 400 > Date.now())
+                this.#validatingTime + this.#beforeFire > Date.now())
                 return;
 
             if (this.#autoEnd) {
@@ -110,12 +113,14 @@ class AutoInput {
                     return this.#callback(this.getCode());
                 this.#validate?.click();
             }
-        }, 400);
+        }, this.#beforeFire);
     }
 
     #onKeyDown(event) {
         const { key, target } = event;
         event.preventDefault();
+
+        this.#validatingTime = 0;
 
         switch (key) {
             case "Backspace":

--- a/src/autoinput.esm.js
+++ b/src/autoinput.esm.js
@@ -12,6 +12,7 @@ class AutoInput {
     #boxes;
     #validatingTime;
     #callback;
+    #isEnable;
 
     /**
      * The AutoInput class
@@ -207,6 +208,27 @@ class AutoInput {
         this.#boxes.forEach((element) => {
             element.value = "";
         });
+    }
+
+    /**
+     * Stop the auto-end event.
+     */
+    stopAutoEnd() {
+        this.#autoEnd = false;
+    }
+
+    /**
+     * Start the auto-end event.
+     */
+    startAutoEnd() {
+        this.#autoEnd = true;
+    }
+
+    /**
+     * Toggle the auto-end event.
+     */
+    toggleAutoEnd() {
+        this.#autoEnd = !this.#autoEnd;
     }
 }
 

--- a/src/autoinput.js
+++ b/src/autoinput.js
@@ -12,6 +12,7 @@ class AutoInput {
     #boxes;
     #validatingTime;
     #callback;
+    #isEnable;
 
     /**
      * The AutoInput class
@@ -207,5 +208,26 @@ class AutoInput {
         this.#boxes.forEach((element) => {
             element.value = "";
         });
+    }
+
+    /**
+     * Stop the auto-end event.
+     */
+    stopAutoEnd() {
+        this.#autoEnd = false;
+    }
+
+    /**
+     * Start the auto-end event.
+     */
+    startAutoEnd() {
+        this.#autoEnd = true;
+    }
+
+    /**
+     * Toggle the auto-end event.
+     */
+    toggleAutoEnd() {
+        this.#autoEnd = !this.#autoEnd;
     }
 }

--- a/src/autoinput.js
+++ b/src/autoinput.js
@@ -5,6 +5,7 @@ class AutoInput {
     #selectAuto;
     #canPast;
     #createAuto;
+    #beforeFire;
     #parent;
     #validate;
     #onCreate;
@@ -19,6 +20,7 @@ class AutoInput {
      * @param {boolean} options.selectAuto If the input should auto select the first input field.
      * @param {boolean} options.canPast If the input should allow pasting.
      * @param {boolean} options.createAuto If the AutoInput should create the HTML inputs automatically.
+     * @param {number} options.beforeFire Will waits `beforeFire` milliseconds before firing the event.
      * @param {Function} options.onCreate The callback when the AutoInput creates the HTML inputs.
      * @param {HTMLElement} options.parent The parent were the child will automatically generate the HTML inputs.
      * @param {HTMLElement} options.validate The validate button to validate the entry.
@@ -28,6 +30,7 @@ class AutoInput {
         this.#selectAuto = options.selectAuto || true;
         this.#canPast = options.canPast || true;
         this.#createAuto = options.createAuto || false;
+        this.#beforeFire = options.beforeFire ?? 400;
         this.#parent = options.parent
                         || document.getElementById("a2fParent")
                         || document.querySelector("[data-parent-a2f]");
@@ -102,7 +105,7 @@ class AutoInput {
 
         setTimeout(() => {
             if (this.#validatingTime &&
-                this.#validatingTime + 400 > Date.now())
+                this.#validatingTime + this.#beforeFire > Date.now())
                 return;
 
             if (this.#autoEnd) {
@@ -110,12 +113,14 @@ class AutoInput {
                     return this.#callback(this.getCode());
                 this.#validate?.click();
             }
-        }, 400);
+        }, this.#beforeFire);
     }
 
     #onKeyDown(event) {
         const { key, target } = event;
         event.preventDefault();
+
+        this.#validatingTime = 0;
 
         switch (key) {
             case "Backspace":


### PR DESCRIPTION
Wait `n` milliseconds when the a2f code is complete and the user didn't do any action before calling the `auto-end` callback.

Allow user to disable the `auto-end` event fired to avoid spam of the callback function (if the user is clicking on the button, which will trigger an action for the browser, so you may need to wait the end of that action before the `auto-end` can fired again).